### PR TITLE
add: faiss-cpu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ langchain==0.0.154
 PyPDF2==3.0.1
 python-dotenv==1.0.0
 streamlit==1.18.1
+faiss-cpu==1.7.4


### PR DESCRIPTION
missing from requirements