### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyPDF2==3.0.1
 python-dotenv==1.0.0
 streamlit==1.18.1
 faiss-cpu==1.7.4
+altair<5


### PR DESCRIPTION
When I import streamlit ModuleNotFoundError: No module named 'altair.vegalite.v4' occurred, I found the following solution by Streamlit Team.
[https://discuss.streamlit.io/t/modulenotfounderror-no-module-named-altair-vegalite-v4/42921/12](url)
there were breaking changes in Altair 5 for Community Cloud.

In the short term, the best solution would be to:
Either: pin altair < 5 or upgrade streamlit to >=1.20.0